### PR TITLE
Guard `data-action` syntax from multiple HTML escapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,12 @@ version links.
 [commits]: https://github.com/seanpdoyle/action_view-attributes
 
 ## main
+
+*   Ensure that attribute values like [data-action](https://stimulus.hotwired.dev/reference/actions)
+    descriptor syntax aren't escaped too many times when transformed to Token Lists
+
+    *Sean Doyle*
+
+## 0.1.0 (Feb 5, 2023)
+
+*   Extract out of [attributes_and_token_lists](https://github.com/seanpdoyle/attributes_and_token_lists)

--- a/lib/action_view/attributes.rb
+++ b/lib/action_view/attributes.rb
@@ -43,8 +43,6 @@ class ActionView::Attributes < DelegateClass(Hash)
 
   private
 
-  delegate :token_list, to: :@view_context
-
   def deep_merge_token_lists(attributes, overrides, namespace:)
     attributes.merge(overrides.to_h) do |name, left, right|
       if token_list?("#{namespace}-#{name.to_s.dasherize}")
@@ -65,5 +63,16 @@ class ActionView::Attributes < DelegateClass(Hash)
 
   def token_list_patterns
     token_lists.select { |token_list| token_list.is_a?(Regexp) }
+  end
+
+  def token_list(left, ...)
+    left =
+      if left.is_a?(String)
+        CGI.unescape_html(left)
+      else
+        left
+      end
+
+    @view_context.token_list(left, ...)
   end
 end

--- a/test/helpers/action_view/attributes/application_helper_test.rb
+++ b/test/helpers/action_view/attributes/application_helper_test.rb
@@ -105,6 +105,16 @@ class ActionView::Attributes::ApplicationHelper::Test < ActionView::TestCase
     assert_equal %(<form data-controller="one two three"></form>), tag.with_attributes(one, two, data: {controller: "three"}).form
   end
 
+  test "tag.with_attributes only escapes once" do
+    attributes = tag.attributes(
+      {data: {action: "click->button#1"}},
+      {data: {action: ["click->button#2", "click->button#3"]}},
+      {data: {action: "click->button#4"}}
+    )
+
+    assert_equal %(data-action="click->button#1 click->button#2 click->button#3 click->button#4"), CGI.unescape_html(attributes.to_s)
+  end
+
   test "with_attributes can have options decorated onto it" do
     with_attributes class: "one two" do |styled|
       assert_equal %(<a class="one two" href="/">styled</a>), styled.link_to("styled", "/")


### PR DESCRIPTION
Prior to this commit, merging a [data-action][] attribute more than once would result in one too many HTML escapes, which would compound in additional merges.

For example, the following merging would result in an invalid descriptor.

```ruby
attributes = tag.attributes(
  {data: {action: "click->button#1"}},
  {data: {action: ["click->button#2", "click->button#3"]}},
  {data: {action: "click->button#4"}}
)

attributes.to_s
 # => %(data-action="click-&gt;button#1 click-&gt;button#2 click-&gt;button#3 click-&gt;button#4")
```

By [unescaping][] each `String` value before passing it to [token_list][] (which re-escapes the value), we can preserve a lossless merging process.

After this commit, the previous example works as expected:

```ruby
attributes = tag.attributes(
  {data: {action: "click->button#1"}},
  {data: {action: ["click->button#2", "click->button#3"]}},
  {data: {action: "click->button#4"}}
)

CGI.unescape_html attributes.to_s
 # => %(data-action="click->button#1 click->button#2 click->button#3 click->button#4")
```

[unescaping]: https://ruby-doc.org/stdlib-2.5.3/libdoc/cgi/rdoc/CGI/Util.html#method-i-unescape_html
[token_list]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-token_list
[data-action]: https://stimulus.hotwired.dev/reference/actions