### PR TITLE
Unescaping `[data-action]` syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ version links.
 
 ## main
 
+*   Special case `data-action` descriptor syntax like `->` when escaping
+    `token_list` calls
+
+    *Sean Doyle*
+
 ## 0.1.1 (Feb 8, 2023)
 
 *   Ensure that attribute values like [data-action](https://stimulus.hotwired.dev/reference/actions)

--- a/lib/action_view/attributes.rb
+++ b/lib/action_view/attributes.rb
@@ -65,14 +65,7 @@ class ActionView::Attributes < DelegateClass(Hash)
     token_lists.select { |token_list| token_list.is_a?(Regexp) }
   end
 
-  def token_list(left, ...)
-    left =
-      if left.is_a?(String)
-        CGI.unescape_html(left)
-      else
-        left
-      end
-
-    @view_context.token_list(left, ...)
+  def token_list(...)
+    @view_context.token_list(...).tap { _1.gsub!("-&gt;", "->") }
   end
 end

--- a/test/helpers/action_view/attributes/application_helper_test.rb
+++ b/test/helpers/action_view/attributes/application_helper_test.rb
@@ -112,7 +112,7 @@ class ActionView::Attributes::ApplicationHelper::Test < ActionView::TestCase
       {data: {action: "click->button#4"}}
     )
 
-    assert_equal %(data-action="click->button#1 click->button#2 click->button#3 click->button#4"), CGI.unescape_html(attributes.to_s)
+    assert_equal %(data-action="click-&gt;button#1 click-&gt;button#2 click-&gt;button#3 click-&gt;button#4"), attributes.to_s
   end
 
   test "with_attributes can have options decorated onto it" do


### PR DESCRIPTION
Special case `data-action` descriptor syntax like `->` when escaping `token_list` calls. Instead of calling `CGI.unescape_html`, search for an escaped version of `->` and unescape it.