### PR TITLE
Drop end-of-life Ruby and Rails versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,22 +9,15 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "2.7"
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"
         rails-version:
-          - "6.1"
-          - "7.0"
           - "7.1"
           - "7.2"
         include:
           - { ruby-version: "3.2", rails-version: "main" }
           - { ruby-version: "3.3", rails-version: "main" }
-        exclude:
-          - { ruby-version: "2.7", rails-version: "7.2" }
-          - { ruby-version: "3.0", rails-version: "7.2" }
 
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ version links.
 
 ## main
 
+*   Drop end-of-life Ruby versions 2.7 and 3.0. Drop end-of-life Rails versions
+    6.1 and 7.0
+
+    *Sean Doyle*
+
 ## 0.2.0 (Oct 24, 2024)
 
 *   Reverse [special casing of `data-action`](#012-feb-8-2023) syntax.

--- a/action_view-attributes.gemspec
+++ b/action_view-attributes.gemspec
@@ -8,11 +8,13 @@ Gem::Specification.new do |spec|
   spec.description = spec.summary
   spec.license = "MIT"
 
+  spec.required_ruby_version = ">= 3.1.0"
+
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/seanpdoyle/action_view-attributes"
   spec.metadata["changelog_uri"] = "https://github.com/seanpdoyle/action_view-attributes/blob/main/CHANGELOG.md"
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", ">= 6.1.3.1"
+  spec.add_dependency "rails", ">= 7.1.0"
 end


### PR DESCRIPTION
Drop end-of-life Ruby versions 2.7 and 3.0. Drop end-of-life Rails versions 6.1 and 7.0