### PR TITLE
Don't special case `->` escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ version links.
 
 ## main
 
+*   Reverse [special casing of `data-action`](#012-feb-8-2023) syntax.
+
+    *Sean Doyle*
+
 ## 0.1.3 (Sep 27, 2024)
 
 *   Expand version matrix to support `ruby@3.3` and `rails@7.2`

--- a/lib/action_view/attributes.rb
+++ b/lib/action_view/attributes.rb
@@ -19,7 +19,7 @@ class ActionView::Attributes < DelegateClass(Hash)
   def merge!(values, &block)
     merge_conflicts = block || proc do |name, left, right|
       if token_list?(name)
-        token_list(left, right)
+        @view_context.token_list(left, right)
       elsif left.respond_to?(:merge) && right.respond_to?(:to_h)
         deep_merge_token_lists left, right, namespace: name
       else
@@ -46,7 +46,7 @@ class ActionView::Attributes < DelegateClass(Hash)
   def deep_merge_token_lists(attributes, overrides, namespace:)
     attributes.merge(overrides.to_h) do |name, left, right|
       if token_list?("#{namespace}-#{name.to_s.dasherize}")
-        token_list(left, right)
+        @view_context.token_list(left, right)
       else
         right
       end
@@ -63,9 +63,5 @@ class ActionView::Attributes < DelegateClass(Hash)
 
   def token_list_patterns
     token_lists.select { |token_list| token_list.is_a?(Regexp) }
-  end
-
-  def token_list(...)
-    @view_context.token_list(...).tap { _1.gsub!("-&gt;", "->") }
   end
 end


### PR DESCRIPTION
Remove special casing for calling [ActiveSupport::SafeBuffer#gsub!][] when merging token lists.

Like [String#gsub!][], calls to [ActiveSupport::SafeBuffer#gsub!][] replace occurrences of one String or pattern with another String. However, calls to both `#gsub` and `#gsub!` mark the `ActiveSupport::SafeBuffer` as HTML unsafe:

```ruby
safe_buffer.html_safe? # => true
safe_buffer.gsub!("-&gt;", "->")
safe_buffer.html_safe? # => false
```

This means that replacements of `-&gt;` with `->` will ultimately be HTML escaped again when rendered.

This also has a negative impact for other HTML entities like `&` (represented as `&amp;`). This makes Tailwind classes like `[&_a]:underline` get escaped twice into `[&amp;amp;_a]:underline`, which breaks in browsers.

[String#gsub!]: https://ruby-doc.org/3.3.5/String.html#method-i-gsub-21
[ActiveSupport::SafeBuffer#gsub!]: https://github.com/rails/rails/blob/7fac5d14d00fcc8dc60b49729abe78223ad3bf00/activesupport/lib/active_support/core_ext/string/output_safety.rb#L165-L190